### PR TITLE
類似判定ロジックを変更_2

### DIFF
--- a/app/controllers/illustrations_controller.rb
+++ b/app/controllers/illustrations_controller.rb
@@ -105,8 +105,9 @@ class IllustrationsController < ApplicationController
 
       # 削除後（更新後）の全画像を取得
       @illustrator = Illustrator.find_by!(name: params[:illustrator_name])
-      
-      # 上記から類似画像を再計算
+
+      # 削除後の状態をBK-Treeに反映してから類似画像を再計算
+      SimilarityApiService.rebuild
       @similar_illustrations = calculate_similar_illustrations(@illustrator.id)
   
       html = render_to_string(
@@ -169,25 +170,8 @@ class IllustrationsController < ApplicationController
   # 類似画像（重複候補）の抽出
   # ==========================================
   def calculate_similar_illustrations(illustrator_id)
-    # -----------------------------------------
-    # 類似のしきい値（この値以下を類似と判定）
-    # -----------------------------------------
-    threshold = 5
-
-    # データベース上で同一イラストレーター内の画像同士を比較し、ハミング距離が閾値以下の画像IDを取得する
-    sql = <<~SQL
-      SELECT DISTINCT i1.id
-      FROM illustrations i1
-      INNER JOIN illustrations i2 
-        ON i1.illustrator_id = i2.illustrator_id
-        AND i1.id != i2.id
-      WHERE i1.illustrator_id = :illustrator_id
-        AND i1.fingerprint IS NOT NULL
-        AND i2.fingerprint IS NOT NULL
-        AND BIT_COUNT(CAST(i1.fingerprint AS UNSIGNED) ^ CAST(i2.fingerprint AS UNSIGNED)) <= :threshold
-    SQL
-
-    similar_ids = Illustration.find_by_sql([sql, { illustrator_id: illustrator_id, threshold: threshold }]).map(&:id)
+    # Go API（BK-Tree）で類似画像のIDリストを取得
+    similar_ids = SimilarityApiService.find_similar_ids(illustrator_id)
 
     direction = params[:sort] == 'asc' ? :asc : :desc
 

--- a/app/controllers/illustrations_controller.rb
+++ b/app/controllers/illustrations_controller.rb
@@ -102,6 +102,7 @@ class IllustrationsController < ApplicationController
     ids = params[:ids]
     # 削除実行
     if ids.present? && Illustration.where(id: ids).destroy_all
+
       begin
         # 削除後（更新後）の全画像を取得
         @illustrator = Illustrator.find_by!(name: params[:illustrator_name])
@@ -127,8 +128,10 @@ class IllustrationsController < ApplicationController
           message: "一括削除に成功しました", 
           html: html 
         }, status: :ok
+
       rescue => e
         Rails.logger.error "類似画像再計算フローで例外が発生しました: #{e.class} #{e.message}"
+
         @similar_illustrations = []
         html = render_to_string(
           partial: 'illustrations/similar_section',
@@ -137,11 +140,13 @@ class IllustrationsController < ApplicationController
             similar_illustrations: @similar_illustrations
           }
         )
+
         render json: {
           message: "一括削除に成功しました",
           html: html
         }, status: :ok
       end
+
     else
       render json: { error: "削除する項目が選択されていないか、失敗しました" }, status: :unprocessable_entity
     end
@@ -190,7 +195,7 @@ class IllustrationsController < ApplicationController
   # 類似画像（重複候補）の抽出
   # ==========================================
   def calculate_similar_illustrations(illustrator_id)
-    # Go API（BK-Tree）で類似画像のIDリストを取得
+    # Go API（BK-Tree）で類似判定を行い、重複候補の画像IDリストを取得
     similar_ids = SimilarityApiService.find_similar_ids(illustrator_id)
 
     direction = params[:sort] == 'asc' ? :asc : :desc

--- a/app/controllers/illustrations_controller.rb
+++ b/app/controllers/illustrations_controller.rb
@@ -102,26 +102,46 @@ class IllustrationsController < ApplicationController
     ids = params[:ids]
     # 削除実行
     if ids.present? && Illustration.where(id: ids).destroy_all
+      begin
+        # 削除後（更新後）の全画像を取得
+        @illustrator = Illustrator.find_by!(name: params[:illustrator_name])
 
-      # 削除後（更新後）の全画像を取得
-      @illustrator = Illustrator.find_by!(name: params[:illustrator_name])
+        # 削除後の状態をBK-Treeに反映してから類似画像を再計算
+        rebuild_success = SimilarityApiService.rebuild
+        if rebuild_success
+          @similar_illustrations = calculate_similar_illustrations(@illustrator.id)
+        else
+          Rails.logger.error "BK-Tree再構築に失敗したため、類似画像の再計算をスキップしました (illustrator_id=#{@illustrator.id})"
+          @similar_illustrations = []
+        end
 
-      # 削除後の状態をBK-Treeに反映してから類似画像を再計算
-      SimilarityApiService.rebuild
-      @similar_illustrations = calculate_similar_illustrations(@illustrator.id)
-  
-      html = render_to_string(
-        partial: 'illustrations/similar_section',
-        formats: [:html],
-        locals: { 
-          similar_illustrations: @similar_illustrations
-        }
-      )
+        html = render_to_string(
+          partial: 'illustrations/similar_section',
+          formats: [:html],
+          locals: { 
+            similar_illustrations: @similar_illustrations
+          }
+        )
 
-      render json: { 
-        message: "一括削除に成功しました", 
-        html: html 
-      }, status: :ok
+        render json: { 
+          message: "一括削除に成功しました", 
+          html: html 
+        }, status: :ok
+      rescue => e
+        Rails.logger.error "類似画像再計算フローで例外が発生しました: #{e.class} #{e.message}"
+        @similar_illustrations = []
+        html = render_to_string(
+          partial: 'illustrations/similar_section',
+          formats: [:html],
+          locals: {
+            similar_illustrations: @similar_illustrations
+          }
+        )
+        render json: {
+          message: "一括削除に成功しました",
+          html: html
+        }, status: :ok
+      end
     else
       render json: { error: "削除する項目が選択されていないか、失敗しました" }, status: :unprocessable_entity
     end

--- a/app/jobs/analyze_illustration_job.rb
+++ b/app/jobs/analyze_illustration_job.rb
@@ -22,9 +22,8 @@ class AnalyzeIllustrationJob < ApplicationJob
         shot_at: @illustration.shot_at, 
         fingerprint: @illustration.fingerprint
       )
-
-      # BK-Treeを再構築（新しい画像のフィンガープリントを類似判定に反映）
-      SimilarityApiService.rebuild
+      # BK-Treeに新しい画像の「類似判定用データ」を追加（再ビルドするのではなく）
+      SimilarityApiService.insert_fingerprint(@illustration)
       
       # サムネ生成・保存
       GenerateThumbnailJob.perform_later(illustration_id)

--- a/app/jobs/analyze_illustration_job.rb
+++ b/app/jobs/analyze_illustration_job.rb
@@ -22,6 +22,7 @@ class AnalyzeIllustrationJob < ApplicationJob
         shot_at: @illustration.shot_at, 
         fingerprint: @illustration.fingerprint
       )
+      
       # BK-Treeに新しい画像の「類似判定用データ」を追加（再ビルドするのではなく）
       SimilarityApiService.insert_fingerprint(@illustration)
       

--- a/app/jobs/analyze_illustration_job.rb
+++ b/app/jobs/analyze_illustration_job.rb
@@ -22,6 +22,9 @@ class AnalyzeIllustrationJob < ApplicationJob
         shot_at: @illustration.shot_at, 
         fingerprint: @illustration.fingerprint
       )
+
+      # BK-Treeを再構築（新しい画像のフィンガープリントを類似判定に反映）
+      SimilarityApiService.rebuild
       
       # サムネ生成・保存
       GenerateThumbnailJob.perform_later(illustration_id)

--- a/app/services/similarity_api_service.rb
+++ b/app/services/similarity_api_service.rb
@@ -37,11 +37,15 @@ class SimilarityApiService
     request = Net::HTTP::Post.new(uri.request_uri)
     response = http.request(request)
 
-    unless response.is_a?(Net::HTTPSuccess)
+    if response.is_a?(Net::HTTPSuccess)
+      true
+    else
       Rails.logger.error "Go API エラー (rebuild): #{response.code} #{response.message}"
+      false
     end
   rescue => e
     Rails.logger.error "Go API への接続に失敗しました (rebuild): #{e.message}"
+    false
   end
 
   # ==========================================================

--- a/app/services/similarity_api_service.rb
+++ b/app/services/similarity_api_service.rb
@@ -14,16 +14,21 @@ class SimilarityApiService
   # ==========================================
   def self.find_similar_ids(illustrator_id, threshold: 5)
     uri = URI.parse("#{BASE_URL}/similarities")
+
+    # パラメータ追加（※しきい値はここで指定）
     uri.query = URI.encode_www_form(
       illustrator_id: illustrator_id,
       threshold: threshold
     )
 
+    # タイムアウト設定（デフォルトだと長いので3秒に設定）
     http = Net::HTTP.new(uri.host, uri.port)
     http.open_timeout = 3
     http.read_timeout = 3
 
     request = Net::HTTP::Get.new(uri.request_uri)
+
+    # あらかじめ作成していたBK-Treeをもとに類似判定をリクエスト（IDのリストが戻る）
     response = http.request(request)
 
     if response.is_a?(Net::HTTPSuccess)
@@ -33,6 +38,7 @@ class SimilarityApiService
       Rails.logger.error "Go API エラー (similarities): #{response.code} #{response.message}"
       []
     end
+
   rescue Net::OpenTimeout, Net::ReadTimeout, Timeout::Error => e
     Rails.logger.error "Go API タイムアウト (similarities): #{e.message}"
     []
@@ -41,15 +47,17 @@ class SimilarityApiService
     []
   end
 
-  # ==========================================
-  # BK-Treeの再構築をリクエスト
-  # 画像の追加・削除後に呼び出す
-  # ==========================================
+  # ============================================================
+  # BK-Treeの再構築をリクエスト（画像の追加・削除後に呼び出す）
+  # ============================================================
   def self.rebuild
     uri = URI.parse("#{BASE_URL}/rebuild")
+    
+    # タイムアウト設定（デフォルトだと長いので3秒に設定）
     http = Net::HTTP.new(uri.host, uri.port)
     http.open_timeout = 3
     http.read_timeout = 3
+
     request = Net::HTTP::Post.new(uri.request_uri)
     response = http.request(request)
 
@@ -59,6 +67,7 @@ class SimilarityApiService
       Rails.logger.error "Go API エラー (rebuild): #{response.code} #{response.message}"
       false
     end
+
   rescue => e
     Rails.logger.error "Go API への接続に失敗しました (rebuild): #{e.message}"
     false
@@ -71,7 +80,9 @@ class SimilarityApiService
     return if illustration.nil? || illustration.fingerprint.blank? || illustration.illustrator_id.blank?
 
     uri = URI.parse("#{BASE_URL}/insert_fingerprint")
+
     http = Net::HTTP.new(uri.host, uri.port)
+
     request = Net::HTTP::Post.new(uri.request_uri, { "Content-Type" => "application/json" })
     request.body = {
       id: illustration.id,
@@ -84,6 +95,7 @@ class SimilarityApiService
     unless response.is_a?(Net::HTTPSuccess)
       Rails.logger.error "Go API エラー (insert_fingerprint): #{response.code} #{response.message}"
     end
+    
   rescue => e
     Rails.logger.error "Go API への接続に失敗しました (insert_fingerprint): #{e.message}"
   end

--- a/app/services/similarity_api_service.rb
+++ b/app/services/similarity_api_service.rb
@@ -1,0 +1,46 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+# ==========================================
+# Go APIとの通信を担当するサービスクラス
+# ==========================================
+class SimilarityApiService
+  BASE_URL = "http://similarity_api:8080"
+
+  # ==========================================
+  # 類似画像のIDリストを取得
+  # ==========================================
+  def self.find_similar_ids(illustrator_id, threshold: 5)
+    uri = URI.parse("#{BASE_URL}/similarities?illustrator_id=#{illustrator_id}&threshold=#{threshold}")
+    response = Net::HTTP.get_response(uri)
+
+    if response.is_a?(Net::HTTPSuccess)
+      data = JSON.parse(response.body)
+      data['similar_ids'] || []
+    else
+      Rails.logger.error "Go API エラー (similarities): #{response.code} #{response.message}"
+      []
+    end
+  rescue => e
+    Rails.logger.error "Go API への接続に失敗しました (similarities): #{e.message}"
+    []
+  end
+
+  # ==========================================
+  # BK-Treeの再構築をリクエスト
+  # 画像の追加・削除後に呼び出す
+  # ==========================================
+  def self.rebuild
+    uri = URI.parse("#{BASE_URL}/rebuild")
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Post.new(uri.request_uri)
+    response = http.request(request)
+
+    unless response.is_a?(Net::HTTPSuccess)
+      Rails.logger.error "Go API エラー (rebuild): #{response.code} #{response.message}"
+    end
+  rescue => e
+    Rails.logger.error "Go API への接続に失敗しました (rebuild): #{e.message}"
+  end
+end

--- a/app/services/similarity_api_service.rb
+++ b/app/services/similarity_api_service.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 require 'uri'
 require 'json'
+require 'timeout'
 
 # ==========================================
 # Go APIとの通信を担当するサービスクラス
@@ -12,8 +13,18 @@ class SimilarityApiService
   # 類似画像のIDリストを取得
   # ==========================================
   def self.find_similar_ids(illustrator_id, threshold: 5)
-    uri = URI.parse("#{BASE_URL}/similarities?illustrator_id=#{illustrator_id}&threshold=#{threshold}")
-    response = Net::HTTP.get_response(uri)
+    uri = URI.parse("#{BASE_URL}/similarities")
+    uri.query = URI.encode_www_form(
+      illustrator_id: illustrator_id,
+      threshold: threshold
+    )
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.open_timeout = 3
+    http.read_timeout = 3
+
+    request = Net::HTTP::Get.new(uri.request_uri)
+    response = http.request(request)
 
     if response.is_a?(Net::HTTPSuccess)
       data = JSON.parse(response.body)
@@ -22,6 +33,9 @@ class SimilarityApiService
       Rails.logger.error "Go API エラー (similarities): #{response.code} #{response.message}"
       []
     end
+  rescue Net::OpenTimeout, Net::ReadTimeout, Timeout::Error => e
+    Rails.logger.error "Go API タイムアウト (similarities): #{e.message}"
+    []
   rescue => e
     Rails.logger.error "Go API への接続に失敗しました (similarities): #{e.message}"
     []
@@ -34,6 +48,8 @@ class SimilarityApiService
   def self.rebuild
     uri = URI.parse("#{BASE_URL}/rebuild")
     http = Net::HTTP.new(uri.host, uri.port)
+    http.open_timeout = 3
+    http.read_timeout = 3
     request = Net::HTTP::Post.new(uri.request_uri)
     response = http.request(request)
 

--- a/app/services/similarity_api_service.rb
+++ b/app/services/similarity_api_service.rb
@@ -43,4 +43,28 @@ class SimilarityApiService
   rescue => e
     Rails.logger.error "Go API への接続に失敗しました (rebuild): #{e.message}"
   end
+
+  # ==========================================================
+  # 単一画像の「類似判定用データ」をBK-Treeに追加
+  # ==========================================================
+  def self.insert_fingerprint(illustration)
+    return if illustration.nil? || illustration.fingerprint.blank? || illustration.illustrator_id.blank?
+
+    uri = URI.parse("#{BASE_URL}/insert_fingerprint")
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Post.new(uri.request_uri, { "Content-Type" => "application/json" })
+    request.body = {
+      id: illustration.id,
+      illustrator_id: illustration.illustrator_id,
+      fingerprint: illustration.fingerprint
+    }.to_json
+
+    response = http.request(request)
+
+    unless response.is_a?(Net::HTTPSuccess)
+      Rails.logger.error "Go API エラー (insert_fingerprint): #{response.code} #{response.message}"
+    end
+  rescue => e
+    Rails.logger.error "Go API への接続に失敗しました (insert_fingerprint): #{e.message}"
+  end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,20 @@ services:
       DATABASE_PASSWORD: password
       REDIS_URL: redis://redis:6379/1
 
+  similarity_api:
+    build: ./go_api
+    container_name: similarity_api
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    environment:
+      DB_USER: root
+      DB_PASSWORD: password
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_NAME: xxx_photos
+
 volumes:
   db_data:
   redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,8 @@ services:
   similarity_api:
     build: ./go_api
     container_name: similarity_api
-    ports:
-      - "8080:8080"
+    expose:
+      - "8080"
     depends_on:
       - db
     environment:

--- a/go_api/Dockerfile
+++ b/go_api/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+COPY . .
+RUN go mod tidy
+RUN go build -o similarity_api main.go
+
+FROM alpine:latest
+WORKDIR /root/
+COPY --from=builder /app/similarity_api .
+EXPOSE 8080
+CMD ["./similarity_api"]

--- a/go_api/go.mod
+++ b/go_api/go.mod
@@ -1,0 +1,5 @@
+module similarity_api
+
+go 1.24
+
+require github.com/go-sql-driver/mysql v1.8.1

--- a/go_api/main.go
+++ b/go_api/main.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/bits"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// ==========================================
+// BK-Tree のデータ構造
+// ==========================================
+
+type BKNode struct {
+	ID          int64
+	Fingerprint uint64
+	Children    map[int]*BKNode
+}
+
+type BKTree struct {
+	Root *BKNode
+}
+
+// =============================================
+// ハミング距離（XORした結果の1のビット数）を計算
+// =============================================
+func hammingDistance(a, b uint64) int {
+	return bits.OnesCount64(a ^ b)
+}
+
+// ==========================================
+// BK-Treeにノードを挿入（O(log N)）
+// ==========================================
+func (t *BKTree) Insert(id int64, fp uint64) {
+	node := &BKNode{
+		ID:          id,
+		Fingerprint: fp,
+		Children:    make(map[int]*BKNode),
+	}
+	if t.Root == nil {
+		t.Root = node
+		return
+	}
+	current := t.Root
+	for {
+		dist := hammingDistance(current.Fingerprint, fp)
+		if child, exists := current.Children[dist]; exists {
+			current = child
+		} else {
+			current.Children[dist] = node
+			return
+		}
+	}
+}
+// ==================================================================
+// BK-Treeから類似ノードを検索（O(log N)）
+// しきい値以下のハミング距離を持つノードのみをたどる「枝刈り」を行う
+// ==================================================================
+func (t *BKTree) Search(fp uint64, threshold int) []int64 {
+	if t.Root == nil {
+		return nil
+	}
+	var results []int64
+	// スタックを使った深さ優先探索
+	stack := []*BKNode{t.Root}
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		dist := hammingDistance(current.Fingerprint, fp)
+		if dist <= threshold {
+			results = append(results, current.ID)
+		}
+		// 枝刈り: dist ± threshold の範囲にある子ノードだけを探索対象に追加
+		// この範囲外の枝は「類似画像が絶対に存在しない」ことが数学的に保証される
+		for childDist, child := range current.Children {
+			if childDist >= dist-threshold && childDist <= dist+threshold {
+				stack = append(stack, child)
+			}
+		}
+	}
+	return results
+}
+
+// ==========================================
+// イラストレーターごとのインメモリデータ
+// ==========================================
+
+type Illustration struct {
+	ID          int64
+	Fingerprint uint64
+}
+
+// イラストレーターごとの木構造と画像リストをセットで管理
+type IllustratorData struct {
+	Tree          *BKTree
+	Illustrations []Illustration
+}
+
+type SimilaritiesResponse struct {
+	SimilarIDs []int64 `json:"similar_ids"`
+}
+
+var db *sql.DB
+
+// イラストレーターIDをキーにしたインメモリデータ
+// 起動時にDBから全件読み込み、以降は /rebuild で更新
+var illustratorDataMap map[int64]*IllustratorData
+var dataMu sync.RWMutex
+
+func main() {
+	initDB()
+	defer db.Close()
+
+	// 起動時に一度だけDBから全データを読み込んでBK-Treeを構築
+	buildAllTrees()
+
+	http.HandleFunc("/similarities", handleSimilarities)
+	http.HandleFunc("/rebuild", handleRebuild)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	log.Printf("Go APIサーバーをポート %s で起動しています...", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatalf("サーバーの起動に失敗しました: %v", err)
+	}
+}
+
+// ==========================================
+// MySQLへの接続を初期化
+// ==========================================
+func initDB() {
+	var err error
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s",
+		os.Getenv("DB_USER"),
+		os.Getenv("DB_PASSWORD"),
+		os.Getenv("DB_HOST"),
+		os.Getenv("DB_PORT"),
+		os.Getenv("DB_NAME"),
+	)
+
+	// docker-compose起動時のDB起動待ちのためのリトライ処理
+	for i := 0; i < 15; i++ {
+		db, err = sql.Open("mysql", dsn)
+		if err == nil {
+			err = db.Ping()
+			if err == nil {
+				log.Println("MySQLへの接続に成功しました")
+				return
+			}
+		}
+		log.Printf("DBの起動を待機しています... %v", err)
+		time.Sleep(2 * time.Second)
+	}
+	log.Fatalf("MySQLへの接続に失敗しました: %v", err)
+}
+
+// ==========================================
+// 全イラストレーターのBK-Treeをメモリ上に構築
+// ==========================================
+func buildAllTrees() {
+	rows, err := db.Query("SELECT id, illustrator_id, fingerprint FROM illustrations WHERE fingerprint IS NOT NULL")
+	if err != nil {
+		log.Printf("BK-Tree構築クエリエラー: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	newMap := make(map[int64]*IllustratorData)
+	count := 0
+	for rows.Next() {
+		var id, illustratorID int64
+		var fp int64 // DBでは符号付き(BIGINT)として保存されている可能性があるためint64で読み込む
+		if err := rows.Scan(&id, &illustratorID, &fp); err != nil {
+			continue
+		}
+		if _, exists := newMap[illustratorID]; !exists {
+			newMap[illustratorID] = &IllustratorData{
+				Tree: &BKTree{},
+			}
+		}
+		ufp := uint64(fp)
+		newMap[illustratorID].Tree.Insert(id, ufp)
+		newMap[illustratorID].Illustrations = append(newMap[illustratorID].Illustrations, Illustration{ID: id, Fingerprint: ufp})
+		count++
+	}
+
+	// 書き込みロックを取得してマップを丸ごと入れ替える
+	dataMu.Lock()
+	illustratorDataMap = newMap
+	dataMu.Unlock()
+
+	log.Printf("BK-Treeの構築が完了しました（全%d件）", count)
+}
+
+// ==========================================
+// 類似画像の検索（/similarities）
+// ==========================================
+func handleSimilarities(w http.ResponseWriter, r *http.Request) {
+	illustratorIDStr := r.URL.Query().Get("illustrator_id")
+	thresholdStr := r.URL.Query().Get("threshold")
+
+	illustratorID, err := strconv.ParseInt(illustratorIDStr, 10, 64)
+	if err != nil {
+		http.Error(w, "illustrator_idが不正です", http.StatusBadRequest)
+		return
+	}
+
+	threshold, err := strconv.Atoi(thresholdStr)
+	if err != nil {
+		threshold = 5 // デフォルトのしきい値
+	}
+
+	// 読み込みロックでマップを参照（複数リクエストの同時読み込みは許可）
+	dataMu.RLock()
+	data, exists := illustratorDataMap[illustratorID]
+	dataMu.RUnlock()
+
+	result := []int64{}
+	if exists && data.Tree.Root != nil {
+		similarIDsMap := make(map[int64]bool)
+
+		// 各画像に対してBK-Treeで検索（O(N log N)）
+		// 総当たりO(N²)とは異なり、枝刈りにより不要な比較をスキップする
+		for _, img := range data.Illustrations {
+			similar := data.Tree.Search(img.Fingerprint, threshold)
+			// 自分自身のみにマッチ（len == 1）の場合は類似画像なしとして除外
+			if len(similar) > 1 {
+				for _, sid := range similar {
+					similarIDsMap[sid] = true
+				}
+			}
+		}
+
+		for id := range similarIDsMap {
+			result = append(result, id)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(SimilaritiesResponse{SimilarIDs: result})
+}
+
+// ==========================================
+// BK-Treeの再構築（/rebuild）
+// 画像の追加・削除後にRailsから呼び出す
+// ==========================================
+func handleRebuild(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POSTメソッドのみ受け付けます", http.StatusMethodNotAllowed)
+		return
+	}
+
+	log.Println("BK-Treeの再構築リクエストを受信しました")
+	// 同期的に実行してから返す（Railsが再構築完了後の検索結果を受け取れるように）
+	buildAllTrees()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "再構築が完了しました"})
+}

--- a/go_api/main.go
+++ b/go_api/main.go
@@ -139,7 +139,14 @@ func main() {
 	}
 
 	log.Printf("Go APIサーバーをポート %s で起動しています...", port)
-	if err := http.ListenAndServe(":"+port, nil); err != nil {
+	server := &http.Server{
+		Addr:         ":" + port,
+		Handler:      nil,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  2 * time.Minute,
+	}
+	if err := server.ListenAndServe(); err != nil {
 		log.Fatalf("サーバーの起動に失敗しました: %v", err)
 	}
 }
@@ -157,28 +164,29 @@ func initDB() {
 		os.Getenv("DB_NAME"),
 	)
 
+	db, err = sql.Open("mysql", dsn)
+	if err != nil {
+		log.Fatalf("MySQL接続初期化に失敗しました: %v", err)
+	}
+
 	// docker-compose起動時のDB起動待ちのためのリトライ処理
 	for i := 0; i < 15; i++ {
-		db, err = sql.Open("mysql", dsn)
+		err = db.Ping()
 		if err == nil {
-			err = db.Ping()
-			if err == nil {
-				log.Println("MySQLへの接続に成功しました")
-				return
-			}
+			log.Println("MySQLへの接続に成功しました")
+			return
 		}
 		log.Printf("DBの起動を待機しています... %v", err)
 		time.Sleep(2 * time.Second)
 	}
+	_ = db.Close()
 	log.Fatalf("MySQLへの接続に失敗しました: %v", err)
 }
 
 // ==========================================
 // 全イラストレーターのBK-Treeをメモリ上に構築
 // ==========================================
-func Verify each finding against current code. Fix only still-valid issues, skip the rest with a brief reason, keep changes minimal, and validate.
-
-In @go_api/main.go around lines 259 - 271, The handleRebuild handler currently allows unauthenticated, synchronous full rebuilds via buildAllTrees(); add a shared-secret check (e.g., read secret from env and validate an Authorization header or X-Rebuild-Token) and return 401 on mismatch, and add an in-flight guard (a package-level atomic flag or mutex) around buildAllTrees() to detect/serialize concurrent requests so if a rebuild is already running you either return 409 or queue/skip the new request; update handleRebuild to validate the token, check/set the in-flight flag, call buildAllTrees(), then clear the flag before responding.() {
+func buildAllTrees() {
 	rows, err := db.Query("SELECT id, illustrator_id, fingerprint FROM illustrations WHERE fingerprint IS NOT NULL")
 	if err != nil {
 		log.Printf("BK-Tree構築クエリエラー: %v", err)
@@ -192,7 +200,8 @@ In @go_api/main.go around lines 259 - 271, The handleRebuild handler currently a
 		var id, illustratorID int64
 		var fp int64 // DBでは符号付き(BIGINT)として保存されている可能性があるためint64で読み込む
 		if err := rows.Scan(&id, &illustratorID, &fp); err != nil {
-			continue
+			log.Printf("BK-Tree構築スキャンエラー: %v (id=%d, illustrator_id=%d)", err, id, illustratorID)
+			return
 		}
 		if _, exists := newMap[illustratorID]; !exists {
 			newMap[illustratorID] = &IllustratorData{
@@ -203,6 +212,10 @@ In @go_api/main.go around lines 259 - 271, The handleRebuild handler currently a
 		newMap[illustratorID].Tree.Insert(id, ufp)
 		newMap[illustratorID].Illustrations = append(newMap[illustratorID].Illustrations, Illustration{ID: id, Fingerprint: ufp})
 		count++
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("BK-Tree構築の行走査エラー: %v", err)
+		return
 	}
 
 	// 書き込みロックを取得してマップを丸ごと入れ替える

--- a/go_api/main.go
+++ b/go_api/main.go
@@ -109,6 +109,12 @@ type SimilaritiesResponse struct {
 	SimilarIDs []int64 `json:"similar_ids"`
 }
 
+type InsertFingerprintRequest struct {
+	ID            int64 `json:"id"`
+	IllustratorID int64 `json:"illustrator_id"`
+	Fingerprint   int64 `json:"fingerprint"`
+}
+
 var db *sql.DB
 
 // イラストレーターIDをキーにしたインメモリデータ
@@ -125,6 +131,7 @@ func main() {
 
 	http.HandleFunc("/similarities", handleSimilarities)
 	http.HandleFunc("/rebuild", handleRebuild)
+	http.HandleFunc("/insert_fingerprint", handleInsertFingerprint)
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -169,7 +176,9 @@ func initDB() {
 // ==========================================
 // 全イラストレーターのBK-Treeをメモリ上に構築
 // ==========================================
-func buildAllTrees() {
+func Verify each finding against current code. Fix only still-valid issues, skip the rest with a brief reason, keep changes minimal, and validate.
+
+In @go_api/main.go around lines 259 - 271, The handleRebuild handler currently allows unauthenticated, synchronous full rebuilds via buildAllTrees(); add a shared-secret check (e.g., read secret from env and validate an Authorization header or X-Rebuild-Token) and return 401 on mismatch, and add an in-flight guard (a package-level atomic flag or mutex) around buildAllTrees() to detect/serialize concurrent requests so if a rebuild is already running you either return 409 or queue/skip the new request; update handleRebuild to validate the token, check/set the in-flight flag, call buildAllTrees(), then clear the flag before responding.() {
 	rows, err := db.Query("SELECT id, illustrator_id, fingerprint FROM illustrations WHERE fingerprint IS NOT NULL")
 	if err != nil {
 		log.Printf("BK-Tree構築クエリエラー: %v", err)
@@ -250,6 +259,50 @@ func handleSimilarities(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(SimilaritiesResponse{SimilarIDs: result})
+}
+
+// ==========================================================
+// 単一画像の「類似判定用データ」をBK-Treeに追加
+// ==========================================================
+func handleInsertFingerprint(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POSTメソッドのみ受け付けます", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req InsertFingerprintRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "リクエストボディのパースに失敗しました", http.StatusBadRequest)
+		return
+	}
+
+	if req.ID == 0 || req.IllustratorID == 0 {
+		http.Error(w, "id または illustrator_id が不正です", http.StatusBadRequest)
+		return
+	}
+
+	ufp := uint64(req.Fingerprint)
+
+	dataMu.Lock()
+	defer dataMu.Unlock()
+
+	if illustratorDataMap == nil {
+		illustratorDataMap = make(map[int64]*IllustratorData)
+	}
+
+	data, exists := illustratorDataMap[req.IllustratorID]
+	if !exists {
+		data = &IllustratorData{
+			Tree: &BKTree{},
+		}
+		illustratorDataMap[req.IllustratorID] = data
+	}
+
+	data.Tree.Insert(req.ID, ufp)
+	data.Illustrations = append(data.Illustrations, Illustration{ID: req.ID, Fingerprint: ufp})
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "inserted"})
 }
 
 // ==========================================

--- a/go_api/main.go
+++ b/go_api/main.go
@@ -18,7 +18,6 @@ import (
 // ==========================================
 // BK-Tree のデータ構造
 // ==========================================
-
 type BKNode struct {
 	ID          int64
 	Fingerprint uint64
@@ -33,25 +32,34 @@ type BKTree struct {
 // ハミング距離（XORした結果の1のビット数）を計算
 // =============================================
 func hammingDistance(a, b uint64) int {
+	// 二つの値を重ねると数値の違うところだけが 1 として浮かび上がる。その数をカウント（= ハミング距離）
 	return bits.OnesCount64(a ^ b)
 }
 
 // ==========================================
-// BK-Treeにノードを挿入（O(log N)）
+// BK-Treeにノードを挿入
+// t: 指定イラストレーターのBK-Tree
+// fp: 更新された画像
 // ==========================================
 func (t *BKTree) Insert(id int64, fp uint64) {
+	// 新しいイラスト用のノードを作成
 	node := &BKNode{
 		ID:          id,
 		Fingerprint: fp,
 		Children:    make(map[int]*BKNode),
 	}
+
+	// 対象イラストレーターのBK-Treeがもしまだなければこれをルートとする（初回アップロード時など）
 	if t.Root == nil {
 		t.Root = node
 		return
 	}
+
 	current := t.Root
 	for {
 		dist := hammingDistance(current.Fingerprint, fp)
+
+		// その距離の枝にすでに画像がある場合、その画像と次のループで比較する（※1枝1ノードのため）
 		if child, exists := current.Children[dist]; exists {
 			current = child
 		} else {
@@ -60,27 +68,33 @@ func (t *BKTree) Insert(id int64, fp uint64) {
 		}
 	}
 }
+
 // ==================================================================
-// BK-Treeから類似ノードを検索（O(log N)）
-// しきい値以下のハミング距離を持つノードのみをたどる「枝刈り」を行う
+// 類似判定
+// t: 指定イラストレーターのBK-Tree
+// fp: 調べたい画像
 // ==================================================================
 func (t *BKTree) Search(fp uint64, threshold int) []int64 {
 	if t.Root == nil {
 		return nil
 	}
-	var results []int64
-	// スタックを使った深さ優先探索
-	stack := []*BKNode{t.Root}
-	for len(stack) > 0 {
-		current := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
 
+	var results []int64
+	stack := []*BKNode{t.Root}  // チェックリスト（スタート地点としてルートを代入）
+
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]  // 1. 調べたい画像（fp）と比較する画像を取得
+		stack = stack[:len(stack)-1]    // 2. 1 をチェックリストから外す
+
+		// 類似判定（1 と fp 間の距離を測定）
 		dist := hammingDistance(current.Fingerprint, fp)
 		if dist <= threshold {
 			results = append(results, current.ID)
 		}
-		// 枝刈り: dist ± threshold の範囲にある子ノードだけを探索対象に追加
-		// この範囲外の枝は「類似画像が絶対に存在しない」ことが数学的に保証される
+
+		// -----------------------------------------------------------------------------------------------
+		// dist ± threshold の範囲にある子ノードだけをチェックリストに追加（※ここで検索対象を大幅に限定できる）
+		// -----------------------------------------------------------------------------------------------
 		for childDist, child := range current.Children {
 			if childDist >= dist-threshold && childDist <= dist+threshold {
 				stack = append(stack, child)
@@ -93,7 +107,6 @@ func (t *BKTree) Search(fp uint64, threshold int) []int64 {
 // ==========================================
 // イラストレーターごとのインメモリデータ
 // ==========================================
-
 type Illustration struct {
 	ID          int64
 	Fingerprint uint64
@@ -118,26 +131,30 @@ type InsertFingerprintRequest struct {
 var db *sql.DB
 
 // イラストレーターIDをキーにしたインメモリデータ
-// 起動時にDBから全件読み込み、以降は /rebuild で更新
 var illustratorDataMap map[int64]*IllustratorData
+
+// BK-Tree（とそれを管理するマップ）へのアクセス権限（鍵）
 var dataMu sync.RWMutex
 
+
 func main() {
+	// MySQLへの接続を確立
 	initDB()
 	defer db.Close()
 
 	// 起動時に一度だけDBから全データを読み込んでBK-Treeを構築
 	buildAllTrees()
 
+	// ルーティング
 	http.HandleFunc("/similarities", handleSimilarities)
 	http.HandleFunc("/rebuild", handleRebuild)
 	http.HandleFunc("/insert_fingerprint", handleInsertFingerprint)
 
+	// サーバー起動
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
 	}
-
 	log.Printf("Go APIサーバーをポート %s で起動しています...", port)
 	server := &http.Server{
 		Addr:         ":" + port,
@@ -152,7 +169,7 @@ func main() {
 }
 
 // ==========================================
-// MySQLへの接続を初期化
+// MySQLへの接続を確立
 // ==========================================
 func initDB() {
 	var err error
@@ -196,29 +213,38 @@ func buildAllTrees() {
 
 	newMap := make(map[int64]*IllustratorData)
 	count := 0
+
 	for rows.Next() {
+		// 列ごとにデータを取得
 		var id, illustratorID int64
-		var fp int64 // DBでは符号付き(BIGINT)として保存されている可能性があるためint64で読み込む
+		var fp int64
 		if err := rows.Scan(&id, &illustratorID, &fp); err != nil {
 			log.Printf("BK-Tree構築スキャンエラー: %v (id=%d, illustrator_id=%d)", err, id, illustratorID)
 			return
 		}
+
+		// イラストレーターごとにBK-Treeのひな型を作成
 		if _, exists := newMap[illustratorID]; !exists {
 			newMap[illustratorID] = &IllustratorData{
 				Tree: &BKTree{},
 			}
 		}
+
+		// BK-Treeに実データを挿入
 		ufp := uint64(fp)
 		newMap[illustratorID].Tree.Insert(id, ufp)
 		newMap[illustratorID].Illustrations = append(newMap[illustratorID].Illustrations, Illustration{ID: id, Fingerprint: ufp})
+
 		count++
 	}
+
+	// ループが正常に終了したかを確認
 	if err := rows.Err(); err != nil {
 		log.Printf("BK-Tree構築の行走査エラー: %v", err)
 		return
 	}
 
-	// 書き込みロックを取得してマップを丸ごと入れ替える
+	// BK-Treeを更新（更新中は他からのBK-Treeへのアクセスをロック）
 	dataMu.Lock()
 	illustratorDataMap = newMap
 	dataMu.Unlock()
@@ -227,7 +253,7 @@ func buildAllTrees() {
 }
 
 // ==========================================
-// 類似画像の検索（/similarities）
+// BK-Treeをもとに類似画像の検索
 // ==========================================
 func handleSimilarities(w http.ResponseWriter, r *http.Request) {
 	illustratorIDStr := r.URL.Query().Get("illustrator_id")
@@ -244,7 +270,7 @@ func handleSimilarities(w http.ResponseWriter, r *http.Request) {
 		threshold = 5 // デフォルトのしきい値
 	}
 
-	// 読み込みロックでマップを参照（複数リクエストの同時読み込みは許可）
+	// 指定されたイラストレーターのBK-Treeを参照
 	dataMu.RLock()
 	data, exists := illustratorDataMap[illustratorID]
 	dataMu.RUnlock()
@@ -253,30 +279,31 @@ func handleSimilarities(w http.ResponseWriter, r *http.Request) {
 	if exists && data.Tree.Root != nil {
 		similarIDsMap := make(map[int64]bool)
 
-		// 各画像に対してBK-Treeで検索（O(N log N)）
-		// 総当たりO(N²)とは異なり、枝刈りにより不要な比較をスキップする
 		for _, img := range data.Illustrations {
+			// 類似判定：対象の画像（img）とBK-Treeを比較
 			similar := data.Tree.Search(img.Fingerprint, threshold)
-			// 自分自身のみにマッチ（len == 1）の場合は類似画像なしとして除外
+
 			if len(similar) > 1 {
 				for _, sid := range similar {
-					similarIDsMap[sid] = true
+					similarIDsMap[sid] = true  // マップに追加（重複分は上書きされる）
 				}
 			}
 		}
 
+		// Rubyで処理できる配列に変換
 		for id := range similarIDsMap {
 			result = append(result, id)
 		}
 	}
 
+	// Rubyにレスポンス
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(SimilaritiesResponse{SimilarIDs: result})
 }
 
-// ==========================================================
-// 単一画像の「類似判定用データ」をBK-Treeに追加
-// ==========================================================
+// ====================================================================
+// 単一画像の「類似判定用データ」をBK-Treeに追加（全件ロード回避のため）
+// ====================================================================
 func handleInsertFingerprint(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "POSTメソッドのみ受け付けます", http.StatusMethodNotAllowed)
@@ -285,7 +312,7 @@ func handleInsertFingerprint(w http.ResponseWriter, r *http.Request) {
 
 	var req InsertFingerprintRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "リクエストボディのパースに失敗しました", http.StatusBadRequest)
+		http.Error(w, "リクエスト内容の解析に失敗しました", http.StatusBadRequest)
 		return
 	}
 
@@ -296,13 +323,14 @@ func handleInsertFingerprint(w http.ResponseWriter, r *http.Request) {
 
 	ufp := uint64(req.Fingerprint)
 
+	// BK-Treeを更新するため他からのアクセスをロック
 	dataMu.Lock()
 	defer dataMu.Unlock()
 
+	// 対象イラストレーターのBK-Treeがもしまだなければひな形を構築（初回アップロード時など）
 	if illustratorDataMap == nil {
 		illustratorDataMap = make(map[int64]*IllustratorData)
 	}
-
 	data, exists := illustratorDataMap[req.IllustratorID]
 	if !exists {
 		data = &IllustratorData{
@@ -311,6 +339,7 @@ func handleInsertFingerprint(w http.ResponseWriter, r *http.Request) {
 		illustratorDataMap[req.IllustratorID] = data
 	}
 
+	// BK-Treeに実データを追加
 	data.Tree.Insert(req.ID, ufp)
 	data.Illustrations = append(data.Illustrations, Illustration{ID: req.ID, Fingerprint: ufp})
 
@@ -319,8 +348,7 @@ func handleInsertFingerprint(w http.ResponseWriter, r *http.Request) {
 }
 
 // ==========================================
-// BK-Treeの再構築（/rebuild）
-// 画像の追加・削除後にRailsから呼び出す
+// BK-Treeの再構築
 // ==========================================
 func handleRebuild(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -329,7 +357,7 @@ func handleRebuild(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Println("BK-Treeの再構築リクエストを受信しました")
-	// 同期的に実行してから返す（Railsが再構築完了後の検索結果を受け取れるように）
+
 	buildAllTrees()
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## 関連Issue
- #32 

## 修正内容

総当たりを廃止し、Go・BK-Tree による類似判定に変更
